### PR TITLE
Fix Google Chrome installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # Chrome installation
-sudo apt install google-chrome-stable
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo dpkg -i google-chrome-stable_current_amd64.deb
 if [ $? -ne 0 ]; then
 	echo "Could not install Chrome. Check your packaging manager. Exitting..."
 	exit 1


### PR DESCRIPTION
Changed command for Chrome installation. Instead of using sudo apt-get chrome stable installation, wget command was used. 

Close bug #16 